### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.3.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ It should contain:
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ### Obtaining API credentials
 
 To obtain API credentials, you need to first register your application on the

--- a/actions/direct_message.yaml
+++ b/actions/direct_message.yaml
@@ -1,6 +1,6 @@
 ---
   name: "direct_message"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Direct message a user."
   enabled: true
   entry_point: "direct_message.py"

--- a/actions/follow.yaml
+++ b/actions/follow.yaml
@@ -1,6 +1,6 @@
 ---
   name: "follow"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Follow a user."
   enabled: true
   entry_point: "follow.py"

--- a/actions/update_status.yaml
+++ b/actions/update_status.yaml
@@ -1,6 +1,6 @@
 ---
   name: "update_status"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Update your status (post a new tweet)."
   enabled: true
   entry_point: "update_status.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - twitter
   - social media
   - social networks
-version : 0.2.0
+version : 0.3.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.