### PR TITLE
New Feature - Upload media with status updates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# 0.4.0
+
+- Added ability to upload media (pictures) in the `update_status` action.
+  Contributed by Nick Maludy (Encore Technologies)
+
 # 0.3.0
 
 - Updated action `runner_type` from `run-python` to `python-script`

--- a/README.md
+++ b/README.md
@@ -66,6 +66,27 @@ the config. When a matching Tweet is found, a trigger is dispatched.
 * ``direct_message`` - Action to direct message a user.
 * ``follow`` - Action to follow a user.
 
+### Updating Status with Media (Pictures)
+
+The ``update_status`` action supports uploading of media (pictures specifically)
+along with your textual status update. This is accomplished by passing
+either the path to a local file, or a ``http/s`` URL to the ``media`` parameter.
+``media`` is an ``array`` and can be used to uploaded multiple media in a single
+tweet.
+
+Example(s):
+
+``` shell
+# upload a single image from the filesystem
+st2 run twitter.update_status status="Check out my local file" media=
+
+# upload a single image from a URL
+st2 run twitter.update_status status="Check out this picutre on the internet" media="https://apod.nasa.gov/apod/image/1806/_SSH1593jsm1024.jpg"
+
+# upload multiple images
+st2 run twitter.update_status status="Check out these pics" media='["/opt/data/picture.png", "https://apod.nasa.gov/apod/image/1806/_SSH1593jsm1024.jpg"]'
+```
+
 ## Rules
 
 ### relay_tweet_to_slack

--- a/actions/update_status.py
+++ b/actions/update_status.py
@@ -1,7 +1,13 @@
+from tempfile import NamedTemporaryFile
 from twitter import Twitter
 from twitter import OAuth
 
+import requests
+
 from st2common.runners.base_action import Action
+
+# 1 MB chunks
+DOWNLOAD_CHUNK_SIZE_BYTES = 1 * 1024 * 1024
 
 __all__ = [
     'UpdateStatusAction'
@@ -9,7 +15,24 @@ __all__ = [
 
 
 class UpdateStatusAction(Action):
-    def run(self, status):
+
+    def http_url_to_file(http_url):
+        data_file = NamedTemporaryFile()
+        req = requests.get(http, stream=True)
+        for chunk in req.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE_BYTES):
+            data_file.write(chunk)
+        return data_file
+
+    def read_media_file_or_url(media_path_or_url):
+        # If media_path_or_url is a URL, then download the file
+        # Else create a file object for the given path
+        if passed_media.startswith('http'):
+            data_file = http_url_to_file(media_path_or_url)
+        else:
+            data_file = open(os.path.realpath(media_path_or_url), 'rb')
+        return data_file.read()
+
+    def run(self, status, media):
         auth = OAuth(
             token=self.config['access_token'],
             token_secret=self.config['access_token_secret'],
@@ -17,6 +40,17 @@ class UpdateStatusAction(Action):
             consumer_secret=self.config['consumer_secret']
         )
         client = Twitter(auth=auth)
-        client.statuses.update(status=status)
+
+        if media:
+            media_ids = []
+            for m in media:
+                imagedata = read_media_file_or_url(m)
+                m_id = t_upload.media.upload(media=imagedata)["media_id_string"]
+                media_ids.append(m_id)
+
+            # - finally send tweet with the list of media ids:
+            client.statuses.update(status=status, media_ids=",".join(media_ids))
+        else:
+            client.statuses.update(status=status)
 
         return True

--- a/actions/update_status.py
+++ b/actions/update_status.py
@@ -1,4 +1,3 @@
-from tempfile import NamedTemporaryFile
 from twitter import Twitter
 from twitter import OAuth
 from twython import Twython

--- a/actions/update_status.yaml
+++ b/actions/update_status.yaml
@@ -9,3 +9,18 @@
       type: "string"
       description: "New status (tweet message)."
       required: true
+    media:
+      type: "array"
+      items:
+        type: "string"
+      description: >
+        Media to post with the status. These can either be local filenames, or
+        http/s URLs. If the item is a URL, the data will be downloaded to
+        a temporary file on the local disk, the uploaded to Twitter.
+        Examples:
+          # path on local filesystem
+          ['/opt/data/image.png']
+
+          # http/s URL that will be downloaded, then uploaded to twitter
+          ['https://imgur.com/abc.png']
+      default: []

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - twitter
   - social media
   - social networks
-version: 0.3.1
+version: 0.4.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
This adds the ability to upload media (pictures) along side tweets in the `update_status` action.

I couldn't get it working with the existing `twitter` library, so i had to use the `twython` library that was already included in `requirements.txt` but used in different actions.

Using this feature as part of a demo for StackStorm allows us to showcase some versatility and provide a cool visual.  Proof that it works: https://twitter.com/NickMaludyDemo/status/1013133343892889601

Here's the workflow i'm using for this.

It goes out to NASA's APOD (Astronomy Picture Of the Day), grabs today's URL, then posts a tweet with the picture: https://github.com/EncoreTechnologies/stackstorm-tutorial/blob/master/actions/workflows/nasa_apod_twitter_post.yaml